### PR TITLE
Added CommissionList

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wildlink/wildlink-api-php",
     "description": "A simple PHP interface for the Wildlink API (learn more at https://www.wildlink.me/)",
     "license": "MIT",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "type": "library",
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -1,14 +1,14 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a12e35b92819eb93f8a8910d09ebda27",
+    "content-hash": "4c564307c3e25dcad682edd65b92a9d2",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/WildlinkApi/CommissionList.php
+++ b/src/WildlinkApi/CommissionList.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace WildlinkApi;
+
+use WildlinkApi\WildlinkClient;
+
+class CommissionList {
+    private $commissions = [];
+    private $commissionCount = 0;
+    protected $currentCommissionIndex = 0;
+    protected $wildlinkClient;
+
+    public function __construct(WildlinkClient $wildlinkClient, $modified_start_date){
+        $this->wildlinkClient = $wildlinkClient;
+        $this->commissions = $wildlinkClient->getAppCommissionsSince($modified_start_date);
+        $this->commissionCount = count($this->commissions);
+    }
+
+    public function getCommissionCount(){
+        return $this->commissionCount;
+    }
+
+    public function getCurrentCommission(){
+        return $this->commissions[$this->currentCommissionIndex];
+    }
+
+    public function getNextCommission(){
+        if ($this->hasNextCommission()){
+            // if we have the commissions in memory, just increase the index and return the record
+            $this->currentCommissionIndex++;
+            return $this->getCurrentCommission();
+        } else {
+            return false;
+        }
+    }
+
+    public function hasNextCommission(){
+        if ($this->currentCommissionIndex < $this->commissionCount - 1){
+            return true;
+        } else {
+            // we don't have another record in memory, so let's fetch another page from the server
+            $this->commissions = $this->wildlinkClient->getPagedCommissions();
+            $this->commissionCount = count($this->commissions);
+
+            // check to see if we got an empty page (the last page)
+            if ($this->commissionCount == 0){
+                return false;
+            } else {
+                $this->currentCommissionIndex = -1; // -1 since we know getNextCommission is about to be called and we don't want to skip the 0th record from the newly returned page of commissions
+                return true;
+            }
+        }
+    }
+}

--- a/src/WildlinkApi/WildlinkClient.php
+++ b/src/WildlinkApi/WildlinkClient.php
@@ -92,6 +92,11 @@ class WildlinkClient
             $api_info->method = 'GET';
         }
 
+        if ($function == 'getAppCommissionsByCursor'){
+            $api_info->endpoint = '/v2/commission?cursor=:cursor&limit=:limit';
+            $api_info->method = 'GET';
+        }
+
         if ($function == 'resendCommissionCallback'){
             $api_info->endpoint = '/v2/commission/:id/send-callback';
             $api_info->method = 'GET';
@@ -209,7 +214,7 @@ class WildlinkClient
             while ($result->NextCursor){
                 $result = $this->request('getEnabledMerchants', [
                     'cursor' => $result->NextCursor,
-                    'limit' => 500
+                    'limit' => 500 // max limit = 500
                 ]);
                 if ($result->Merchants){
                     $merchants = array_merge($merchants, $result->Merchants);
@@ -234,7 +239,7 @@ class WildlinkClient
             while ($result->NextCursor){
                 $result = $this->request('getDisabledMerchants', [
                     'cursor' => $result->NextCursor,
-                    'limit' => 500
+                    'limit' => 500 // max limit = 500
                 ]);
                 if ($result->Merchants){
                     $disabledMerchants = array_merge($disabledMerchants, $result->Merchants);
@@ -254,7 +259,7 @@ class WildlinkClient
 
         $result = $this->request('getEnabledMerchants', [
             'cursor' => $this->merchantListCursor,
-            'limit' => 500
+            'limit' => 500 // max limit = 500
         ]);
         if (!isset($result->Merchants)){
             return $result;
@@ -272,7 +277,7 @@ class WildlinkClient
 
         $result = $this->request('getDisabledMerchants', [
             'cursor' => $this->merchantListCursor,
-            'limit' => 500
+            'limit' => 500 // max limit = 500
         ]);
         if (!isset($result->Merchants)){
             return $result;
@@ -297,11 +302,20 @@ class WildlinkClient
 
     public function getAppCommissionsSince($modified_since, $limit = '')
     {
+        if (!isset($this->commissionListCursor)){
+            $this->commissionListCursor = '';
+        }
+
         $result = $this->request('getAppCommissionsSince', [
             'modified_since' => $modified_since,
             'limit' => $limit
         ]);
-        return $result;
+        if (!isset($result->Commissions)){
+            return $result;
+        } else {
+            $this->commissionListCursor = $result->NextCursor;
+            return $result->Commissions;
+        }
     }
 
     public function resendCommissionCallback($commission_id)
@@ -310,6 +324,24 @@ class WildlinkClient
             'id' => $commission_id
         ]);
         return $result;
+    }
+
+    public function getPagedCommissions()
+    {
+        if (!isset($this->commissionListCursor)){
+            $this->commissionListCursor = '';
+        }
+
+        $result = $this->request('getAppCommissionsByCursor', [
+            'cursor' => $this->commissionListCursor,
+            'limit' => 100 // max limit = 100
+        ]);
+        if (!isset($result->Commissions)){
+            return $result;
+        } else {
+            $this->commissionListCursor = $result->NextCursor;
+            return $result->Commissions;
+        }
     }
 
 

--- a/tests/test.php
+++ b/tests/test.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../vendor/autoload.php'; // Autoload files using Compos
 
 use WildlinkApi\WildlinkClient;
 use WildlinkApi\MerchantList;
+use WildlinkApi\CommissionList;
 use WildlinkApi\DisabledMerchantList;
 
 function out($str, $type = ''){
@@ -114,16 +115,24 @@ while ($merchant = $disabledMerchantList->getCurrentMerchant()){
         break;
     }
 }
-
 out("total DISABLED merchant count: " . $merchantCounter);
 
-
 // get all commissions for app (across all devices)
-$commissions_since_date = '2018-07-01';
-$commissions_since_limit = 10;
-out("testing get all comissions for app since $commissions_since_date, limit $commissions_since_limit");
-$allCommissionsSince = $wfClient->getAppCommissionsSince($commissions_since_date, $commissions_since_limit);
-out($allCommissionsSince);
+$commissions_since_date = '2018-01-01';
+out("testing get all comissions for app since $commissions_since_date");
+$commissionList = new CommissionList($wfClient, $commissions_since_date);
+
+$commissionCounter = 0;
+while ($commission = $commissionList->getCurrentCommission()){
+    out($commissionCounter);
+    out($commission);
+    $commissionCounter++;
+    if ($commissionList->hasNextCommission()){
+        $commissionList->getNextCommission();
+    } else {
+        break;
+    }
+}
 
 // re-send most recent commission record callback
 $commission_id = $allCommissionsSince->Commissions[0]->ID;


### PR DESCRIPTION
Previous version had a single "get all commissions" method but didn't handle pagination.  This version adds a CommissionList object (similar to MerchantList) that the consumer can cycle through and it will fetch next pages as needed.  Instantiation of the MerchantList object expects a "modified since" as a second parameter.